### PR TITLE
Revert reminders

### DIFF
--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -7,11 +7,19 @@ export default Ember.Controller.extend({
     toggleEditing() {
       this.toggleProperty('isEditing', true);
     },
+
     update() {
       this.get('model').save().then(() => {
         this.setProperties({ title: '', date: '', notes: '' });
       });
       this.toggleProperty('isEditing');
+    },
+
+    revertChanges(id) {
+      console.log('Revert Clicked', id);
+      this.get('store').findRecord('reminder', id).then((reminder) => {
+        reminder.rollbackAttributes();
+      });
     }
-  }
+  },
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -16,7 +16,6 @@ export default Ember.Controller.extend({
     },
 
     revertChanges(id) {
-      console.log('Revert Clicked', id);
       this.get('store').findRecord('reminder', id).then((reminder) => {
         reminder.rollbackAttributes();
       });

--- a/app/styles/_new-form.scss
+++ b/app/styles/_new-form.scss
@@ -22,6 +22,6 @@
 
 .save-button {
   @include button-format;
-  margin-top: 15px;
+  margin: 15px 0;
   width: 60px;
 }

--- a/app/styles/_reminder-details.scss
+++ b/app/styles/_reminder-details.scss
@@ -27,7 +27,3 @@
 .edit-button {
   margin-right: 15px;
 }
-
-.revert-button:disabled {
-// greyish color like sidebar background?
-}

--- a/app/styles/_reminder-details.scss
+++ b/app/styles/_reminder-details.scss
@@ -18,11 +18,16 @@
 }
 
 .edit-button,
-.pin-button {
+.pin-button,
+.revert-button {
   @include button-format;
   padding: 2px 10px;
 }
 
 .edit-button {
   margin-right: 15px;
+}
+
+.revert-button:disabled {
+// greyish color like sidebar background?
 }

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,9 +1,13 @@
+{{#with model as |reminder| }}
+
 <div class="reminder-details">
   <h1 class="spec-reminder-title">{{model.title}}</h1>
 
   {{#if isEditing}}
 
     {{reminder-form reminder=model submitForm=(action "update")}}
+    <button type="button" name="button" class="revert-button" {{action "revertChanges" reminder.id on="click"}}>Revert</button>
+
 
   {{else}}
 
@@ -14,8 +18,11 @@
     {{/if}}
 
     <button type="button" name="button" class="edit-button" {{action "toggleEditing"}}>Edit Reminder</button>
-    <button type="button" name="button" class="pin-button">Pin Reminder</button>
+    {{!-- <button type="button" name="button" class="pin-button">Pin Reminder</button> --}}
+
 
   {{/if}}
 
 </div>
+
+{{/with}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -6,6 +6,7 @@
   {{#if isEditing}}
 
     {{reminder-form reminder=model submitForm=(action "update")}}
+    
     <button type="button" name="button" class="revert-button" {{action "revertChanges" reminder.id on="click"}}>Revert</button>
 
 

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -9,7 +9,6 @@
 
     <button type="button" name="button" class="revert-button" {{action "revertChanges" reminder.id on="click"}}>Revert</button>
 
-
   {{else}}
 
     <p class="spec-reminder-date">{{model.date}}</p>

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -6,7 +6,7 @@
   {{#if isEditing}}
 
     {{reminder-form reminder=model submitForm=(action "update")}}
-    
+
     <button type="button" name="button" class="revert-button" {{action "revertChanges" reminder.id on="click"}}>Revert</button>
 
 
@@ -19,8 +19,6 @@
     {{/if}}
 
     <button type="button" name="button" class="edit-button" {{action "toggleEditing"}}>Edit Reminder</button>
-    {{!-- <button type="button" name="button" class="pin-button">Pin Reminder</button> --}}
-
 
   {{/if}}
 

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -81,4 +81,44 @@ test('clicking on "Edit reminder" button allows the user to edit the reminder', 
   andThen(function() {
     assert.equal(find('.reminder-title-input').val(), 'feed the dog');
   });
+
+  click('.save-button');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'feed the dog');
+  });
+});
+
+test('when in edit mode, clicking the "Revert" button rolls back any changes made to reminder', function(assert) {
+
+  visit('/');
+  click('.add-new-button');
+  fillIn('.reminder-title-input', 'feed the dog');
+
+  andThen(function() {
+    assert.equal(find('.reminder-title-input').val(), 'feed the dog');
+  });
+
+  click('.save-button');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'feed the dog');
+  });
+  
+  click('.spec-reminder-item:last');
+  click('.edit-button');
+  andThen(function() {
+    assert.equal(find('.reminder-title-input').val(), 'feed the dog');
+  });
+
+  fillIn('.reminder-title-input', 'feed the cat');
+  andThen(function() {
+    assert.equal(find('.reminder-title-input').val(), 'feed the cat');
+  });
+
+  click('.revert-button');
+  andThen(function() {
+    assert.equal(find('.reminder-title-input').val(), 'feed the dog');
+  });
+
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -54,7 +54,7 @@ test('clicking on "Add reminder" button creates a new reminder', function(assert
 
   andThen(function() {
     assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'do laundry');
-    assert.equal(Ember.$('.reminder-date:last').text().trim(), 'Wednesday, Oct 12th 2016');
+    assert.equal(Ember.$('.reminder-date:last').text().trim(), '2016-10-12');
   });
 });
 
@@ -104,7 +104,7 @@ test('when in edit mode, clicking the "Revert" button rolls back any changes mad
   andThen(function() {
     assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'feed the dog');
   });
-  
+
   click('.spec-reminder-item:last');
   click('.edit-button');
   andThen(function() {


### PR DESCRIPTION
@stevekinney @brittanystoroz @martensonbj 

## Purpose

When the user is in the edit mode, they can rollback any changes they have made before saving the existing reminder by clicking on the "revert" button.

## Approach

We created another action in the controller that is called when the "revert" button is clicked.

### Learning

We looked at the Ember docs about creating, updating and deleting records:
[Ember Guides](https://guides.emberjs.com/v2.8.0/models/creating-updating-and-deleting-records/)

### Test coverage 

The test creates a new reminder, simulates a user clicking into edit mode and makes a change to the title. Before the new title is saved, the test simulates a click of the "revert" button to undo changes back to the existing title.

### Follow-up tasks

Receive feature #6

### Screenshots

![Video](http://g.recordit.co/GhkwBEgD7M.gif)

Closes #11 